### PR TITLE
Mark `as_mut_ptr` as unsafe and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comptr"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["msiglreith <msiglreith@users.noreply.github.com>"]
 license = "MIT"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ impl<T> ComPtr<T> {
     }
 
     #[inline]
-    pub fn as_mut_ptr(&self) -> *mut T {
+    pub unsafe fn as_mut_ptr(&self) -> *mut T {
         self.pointer
     }
 


### PR DESCRIPTION
cc #1 

Edit: I'm waiting a bit before merging as it probably will break `gfx-rs` master